### PR TITLE
Thankyou! will no longer display when false or an empty string are passed

### DIFF
--- a/src/livevalidation_standalone.js
+++ b/src/livevalidation_standalone.js
@@ -96,7 +96,7 @@ LiveValidation.prototype = {
       this.form = this.element.form;
       // options
       var options = optionsObj || {};
-      this.validMessage = options.validMessage || 'Thankyou!';
+      this.validMessage = (options.validMessage === false || options.validMessage === '' || options.validMessage)? options.validMessage : 'Thankyou!';
       var node = options.insertAfterWhatNode || this.element;
 	  this.insertAfterWhatNode = node.nodeType ? node : document.getElementById(node);
       this.onlyOnBlur =  options.onlyOnBlur || false;


### PR DESCRIPTION
Thankyou! will no longer display when false or an empty string are passed to the validMessage option for the standalong version.  Bug appears to be related to the use of the javascript or operator being used for assignment and so should not affect the Prototype version.
